### PR TITLE
CI workflow & clippy linter fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add clippy
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -A clippy::unused_unit -D warnings

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use std::{fs, path::PathBuf};
 use toml::value::Table;
 
 /// Name of the main config file in the app's folder
-pub const FILENAME: &'static str = "niobium.config";
+pub const FILENAME: &str = "niobium.config";
 
 /// The app's config
 #[allow(non_snake_case)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ async fn get_gallery(
             // Check if this path exists
             if gallery.path_exists(&path).await {
                 // This path exists in the gallery, calculate the content of the nav panel
-                match NavData::from_path(&path, &gallery, None).await {
+                match NavData::from_path(&path, gallery, None).await {
                     // Render the template
                     Ok(nav_data) => PageResult::Page(Template::render(
                         "main",
@@ -128,7 +128,7 @@ async fn get_gallery(
                     }
                 }
             } else {
-                page_404(&config)
+                page_404(config)
             }
         }
 
@@ -153,6 +153,7 @@ async fn get_gallery(
 
 /// Route handler called by javascript to return the grid items for the given path and parameters
 #[get("/<path..>?grid&<start>&<count>&<uid>", rank = 10)]
+#[allow(clippy::too_many_arguments)]
 async fn get_grid(
     path: PathBuf,
     start: Option<usize>,
@@ -206,7 +207,7 @@ async fn get_grid(
         }
 
         // A password is required and is either missing or invalid
-        Err(error) => PageResult::PasswordRequired(error.message().to_string()),
+        Err(error) => PageResult::PasswordRequired(error.message()),
     }
 }
 
@@ -222,7 +223,7 @@ async fn get_nav(
     // Check if a password is required to access this path
     match gallery.check_password(&path, cookies, &password).await {
         // Either no password is required or a valid one has been provided
-        Ok(passwords) => match NavData::from_path(&path, &gallery, Some(passwords)).await {
+        Ok(passwords) => match NavData::from_path(&path, gallery, Some(passwords)).await {
             Ok(nav_data) => PageResult::Page(Template::render(
                 "nav",
                 context! {
@@ -241,7 +242,7 @@ async fn get_nav(
         },
 
         // A password is required and is either missing or invalid
-        Err(error) => PageResult::PasswordRequired(error.message().to_string()),
+        Err(error) => PageResult::PasswordRequired(error.message()),
     }
 }
 
@@ -260,20 +261,20 @@ async fn get_grid_item(uid: UID, gallery: &State<Gallery>, config: &State<Config
                 url_download_photo:uri!(download_photo(&uid)),
             },
         )),
-        None => page_404(&config),
+        None => page_404(config),
     }
 }
 
 /// Route handler that returns the thumbnail version of the requested UID
 #[get("/<uid>/thumbnail", rank = 3)]
 async fn get_thumbnail(uid: UID, gallery: &State<Gallery>, config: &State<Config>) -> PageResult {
-    get_resized(&uid, photos::ResizedType::THUMBNAIL, &gallery, &config).await
+    get_resized(&uid, photos::ResizedType::THUMBNAIL, gallery, config).await
 }
 
 /// Route handler that returns the large resized version of the requested UID
 #[get("/<uid>/large", rank = 4)]
 async fn get_large(uid: UID, gallery: &State<Gallery>, config: &State<Config>) -> PageResult {
-    get_resized(&uid, photos::ResizedType::LARGE, &gallery, &config).await
+    get_resized(&uid, photos::ResizedType::LARGE, gallery, config).await
 }
 
 /// Returns the resized version of the requested UID for the given prefix
@@ -302,7 +303,7 @@ async fn get_resized(
                 }
             }
         }
-        Ok(None) => page_404(&config),
+        Ok(None) => page_404(config),
         Err(error) => {
             eprintln!(
                 "Error : unable to return a resized photo for UID #{} : {}",
@@ -331,7 +332,7 @@ async fn get_photo(uid: UID, gallery: &State<Gallery>, config: &State<Config>) -
                 }
             }
         }
-        None => page_404(&config),
+        None => page_404(config),
     }
 }
 
@@ -341,7 +342,7 @@ async fn download_photo(uid: UID, gallery: &State<Gallery>, config: &State<Confi
     match gallery.get_from_uid(&uid).await {
         Some(photo) => {
             // Try to open the file
-            match DownloadedNamedFile::open(&photo.full_path, &photo.uid, &config).await {
+            match DownloadedNamedFile::open(&photo.full_path, &photo.uid, config).await {
                 Ok(file) => PageResult::PhotoDownload(file),
                 Err(error) => {
                     eprintln!(
@@ -353,7 +354,7 @@ async fn download_photo(uid: UID, gallery: &State<Gallery>, config: &State<Confi
                 }
             }
         }
-        None => page_404(&config),
+        None => page_404(config),
     }
 }
 
@@ -414,8 +415,7 @@ impl DownloadedNamedFile {
                 rocket::http::hyper::header::CONTENT_DISPOSITION.as_str(),
                 format!(
                     "attachment; filename=\"{}{}.jpg\"",
-                    &config.DOWNLOAD_PREFIX,
-                    uid.to_string()
+                    &config.DOWNLOAD_PREFIX, uid
                 ),
             ),
         })

--- a/src/password.rs
+++ b/src/password.rs
@@ -99,14 +99,14 @@ impl PasswordError {
         match self {
             PasswordError::Required(path) => {
                 if path.is_empty() {
-                    format!("A password is required to access this gallery")
+                    "A password is required to access this gallery".to_string()
                 } else {
                     format!("A password is required to access \"{}\"", path)
                 }
             }
             PasswordError::Invalid(path) => {
                 if path.is_empty() {
-                    format!("Invalid password")
+                    "Invalid password".to_string()
                 } else {
                     format!("Invalid password for \"{}\"", path)
                 }

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -8,6 +8,7 @@ use rocket::request::FromParam;
 use rocket::serde::Serialize;
 
 #[derive(Default, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct UID {
     uid: String,
 }
@@ -59,11 +60,11 @@ impl UID {
     pub const CHARS: &str = "0123456789abcdefghijklmnopqrstuvwxyz";
 
     /// Generate an UID of the given length that doesn't already exist in the given list
-    pub fn new(existing_uids: &Vec<Self>) -> Self {
+    pub fn new(existing_uids: &[Self]) -> Self {
         let mut rng = thread_rng();
         loop {
             let uid_string = Self::CHARS_BIASED
-                .choose_multiple_weighted(&mut rng, Self::LENGTH as usize, |item| item.1)
+                .choose_multiple_weighted(&mut rng, Self::LENGTH, |item| item.1)
                 .expect("Error : invalid weight value for choose_multiple_weighted()")
                 .map(|item| String::from(item.0))
                 .collect::<Vec<String>>()
@@ -128,9 +129,9 @@ impl<'r> FromParam<'r> for UID {
         let mut s = param;
         if &s[0..=0] == "." {
             s = &s[1..];
-            Self::try_from(s).or_else(|_| return Err(param))
+            Self::try_from(s).map_err(|_| param)
         } else {
-            return Err(param);
+            Err(param)
         }
     }
 }


### PR DESCRIPTION
Add GitHub action CI workflow for running [`rustfmt`](https://github.com/rust-lang/rustfmt) and [`clippy`](https://github.com/rust-lang/rust-clippy). Also fix most clippy warnings and allow the last remaining one via  `-A clippy::unused_unit` CLI argument to get clippy passing without warnings.